### PR TITLE
Adds support for (newer) Original Xbox DVT3 HDDs

### DIFF
--- a/FATX/DriveReader.cs
+++ b/FATX/DriveReader.cs
@@ -47,6 +47,20 @@ namespace FATX
                 return;
             }
 
+            // Check for Original XBOX DVT3 (Prototype Development Kit) partition.
+            Seek(0x80000);
+            if (ReadUInt32() == 0x58544146)
+            {
+                Console.WriteLine("Mounting Xbox DVT3 HDD (v2)..");
+
+                AddPartition("Partition1", 0x80000, 0x1312D6000);        // DATA
+                AddPartition("Partition2", 0x131356000, 0x1f400000);     // SHELL
+                AddPartition("Partition3", 0x150756000, 0x2ee00000);     // CACHE
+                AddPartition("Partition4", 0x17F556000, 0x2ee00000);     // CACHE
+                AddPartition("Partition5", 0x1AE356000, 0x2ee00000);     // CACHE
+                return;
+            }
+
             // Check for XBOX 360 partitions.
             Seek(0);
             ByteOrder = ByteOrder.Big;

--- a/FATX/DriveReader.cs
+++ b/FATX/DriveReader.cs
@@ -44,94 +44,93 @@ namespace FATX
                 AddPartition("Partition3", 0x5DC80000, 0x2ee00000);     // CACHE
                 AddPartition("Partition4", 0x2EE80000, 0x2ee00000);     // CACHE
                 AddPartition("Partition5", 0x80000, 0x2ee00000);        // CACHE
+                return;
+            }
+
+            // Check for XBOX 360 partitions.
+            Seek(0);
+            ByteOrder = ByteOrder.Big;
+            if (ReadUInt32() == 0x20000)
+            {
+                Console.WriteLine("Mounting Xbox 360 Dev HDD..");
+
+                // This is a dev formatted HDD.
+                ReadUInt16();  // Kernel version
+                ReadUInt16();
+
+                // TODO: reading from raw devices requires sector aligned reads.
+                Seek(8);
+                // Partition1
+                long dataOffset = (long)ReadUInt32() * Constants.SectorSize;
+                long dataLength = (long)ReadUInt32() * Constants.SectorSize;
+                // SystemPartition
+                long shellOffset = (long)ReadUInt32() * Constants.SectorSize;
+                long shellLength = (long)ReadUInt32() * Constants.SectorSize;
+                // Unused?
+                ReadUInt32();
+                ReadUInt32();
+                // DumpPartition
+                ReadUInt32();
+                ReadUInt32();
+                // PixDump
+                ReadUInt32();
+                ReadUInt32();
+                // Unused?
+                ReadUInt32();
+                ReadUInt32();
+                // Unused?
+                ReadUInt32();
+                ReadUInt32();
+                // AltFlash
+                ReadUInt32();
+                ReadUInt32();
+                // Cache0
+                long cache0Offset = (long)ReadUInt32() * Constants.SectorSize;
+                long cache0Length = (long)ReadUInt32() * Constants.SectorSize;
+                // Cache1
+                long cache1Offset = (long)ReadUInt32() * Constants.SectorSize;
+                long cache1Length = (long)ReadUInt32() * Constants.SectorSize;
+
+                AddPartition("Partition1", dataOffset, dataLength);
+                AddPartition("SystemPartition", shellOffset, shellLength);
+                // TODO: Add support for these
+                //AddPartition("Cache0", cache0Offset, cache0Length);
+                //AddPartition("Cache1", cache1Offset, cache1Length);
             }
             else
             {
-                // Check for XBOX 360 partitions.
-                Seek(0);
-                ByteOrder = ByteOrder.Big;
-                if (ReadUInt32() == 0x20000)
-                {
-                    Console.WriteLine("Mounting Xbox 360 Dev HDD..");
+                Console.WriteLine("Mounting Xbox 360 Retail HDD..");
 
-                    // This is a dev formatted HDD.
-                    ReadUInt16();  // Kernel version
-                    ReadUInt16();
+                //Seek(8);
+                //var test = ReadUInt32();
 
-                    // TODO: reading from raw devices requires sector aligned reads.
-                    Seek(8);
-                    // Partition1
-                    long dataOffset = (long)ReadUInt32() * Constants.SectorSize;
-                    long dataLength = (long)ReadUInt32() * Constants.SectorSize;
-                    // SystemPartition
-                    long shellOffset = (long)ReadUInt32() * Constants.SectorSize;
-                    long shellLength = (long)ReadUInt32() * Constants.SectorSize;
-                    // Unused?
-                    ReadUInt32();
-                    ReadUInt32();
-                    // DumpPartition
-                    ReadUInt32();
-                    ReadUInt32();
-                    // PixDump
-                    ReadUInt32();
-                    ReadUInt32();
-                    // Unused?
-                    ReadUInt32();
-                    ReadUInt32();
-                    // Unused?
-                    ReadUInt32();
-                    ReadUInt32();
-                    // AltFlash
-                    ReadUInt32();
-                    ReadUInt32();
-                    // Cache0
-                    long cache0Offset = (long)ReadUInt32() * Constants.SectorSize;
-                    long cache0Length = (long)ReadUInt32() * Constants.SectorSize;
-                    // Cache1
-                    long cache1Offset = (long)ReadUInt32() * Constants.SectorSize;
-                    long cache1Length = (long)ReadUInt32() * Constants.SectorSize;
+                // This is a retail formatted HDD.
+                /// Partition0 0, END
+                /// Cache0 0x80000, 0x80000000
+                /// Cache1 0x80080000, 0x80000000
+                /// DumpPartition 0x100080000, 0x20E30000
+                ///   SystemURLCachePartition 0, 0x6000000
+                ///   TitleURLCachePartition 0x6000000, 0x2000000
+                ///   SystemExtPartition 0x0C000000, 0x0CE30000
+                ///   SystemAuxPartition 0x18e30000, 0x08000000
+                /// SystemPartition 0x120EB0000, 0x10000000
+                /// Partition1 0x130EB0000, END
 
-                    AddPartition("Partition1", dataOffset, dataLength);
-                    AddPartition("SystemPartition", shellOffset, shellLength);
-                    // TODO: Add support for these
-                    //AddPartition("Cache0", cache0Offset, cache0Length);
-                    //AddPartition("Cache1", cache1Offset, cache1Length);
-                }
-                else
-                {
-                    Console.WriteLine("Mounting Xbox 360 Retail HDD..");
+                AddPartition("Partition1", 0x130eb0000, this.Length - 0x130eb0000);
+                AddPartition("SystemPartition", 0x120eb0000, 0x10000000);
 
-                    //Seek(8);
-                    //var test = ReadUInt32();
+                // 0x118EB0000 - 0x100080000
+                // TODO: Add support for these
+                //AddPartition("Cache0", 0x80000, 0x80000000);
+                //AddPartition("Cache1", 0x80080000, 0x80000000);
 
-                    // This is a retail formatted HDD.
-                    /// Partition0 0, END
-                    /// Cache0 0x80000, 0x80000000
-                    /// Cache1 0x80080000, 0x80000000
-                    /// DumpPartition 0x100080000, 0x20E30000
-                    ///   SystemURLCachePartition 0, 0x6000000
-                    ///   TitleURLCachePartition 0x6000000, 0x2000000
-                    ///   SystemExtPartition 0x0C000000, 0x0CE30000
-                    ///   SystemAuxPartition 0x18e30000, 0x08000000
-                    /// SystemPartition 0x120EB0000, 0x10000000
-                    /// Partition1 0x130EB0000, END
-
-                    AddPartition("Partition1", 0x130eb0000, this.Length - 0x130eb0000);
-                    AddPartition("SystemPartition", 0x120eb0000, 0x10000000);
-
-                    // 0x118EB0000 - 0x100080000
-                    // TODO: Add support for these
-                    //AddPartition("Cache0", 0x80000, 0x80000000);
-                    //AddPartition("Cache1", 0x80080000, 0x80000000);
-
-                    const long dumpPartitionOffset = 0x100080000;
-                    // TODO: Add support for these
-                    //AddPartition("DumpPartition", 0x100080000, 0x20E30000);
-                    //AddPartition("SystemURLCachePartition", dumpPartitionOffset + 0, 0x6000000);
-                    //AddPartition("TitleURLCachePartition", dumpPartitionOffset + 0x6000000, 0x2000000);
-                    //AddPartition("SystemExtPartition", dumpPartitionOffset + 0x0C000000, 0xCE30000);
-                    AddPartition("SystemAuxPartition", dumpPartitionOffset + 0x18e30000, 0x8000000);
-                }
+                const long dumpPartitionOffset = 0x100080000;
+                // TODO: Add support for these
+                //AddPartition("DumpPartition", 0x100080000, 0x20E30000);
+                //AddPartition("SystemURLCachePartition", dumpPartitionOffset + 0, 0x6000000);
+                //AddPartition("TitleURLCachePartition", dumpPartitionOffset + 0x6000000, 0x2000000);
+                //AddPartition("SystemExtPartition", dumpPartitionOffset + 0x0C000000, 0xCE30000);
+                AddPartition("SystemAuxPartition", dumpPartitionOffset + 0x18e30000, 0x8000000);
             }
         }
 


### PR DESCRIPTION
DVT3 are prototype development kits for the original xbox that were given to developers from June 2001 to August 2001. For systems running the July/August 2001 kernel, the partition order appears to be reversed but otherwise identical to retail FATX.

It appears that May / June kernels used a rather different FATX/HDD partition formats. This may or may not be the 'alpha' hdd format mentioned in #28.

I can supply a HDD image for this 'v2' DVT3 format, and the older 'v1' (alpha?) if you are interested along with a few notes or an IDB if you are interested.

Edit: also I split the commits for this change because otherwise it was harder to see the DVT3-specific logic I was adding, muddying the PR.