### PR TITLE
Fix "Not a valid Win32 FileTime" exception

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,11 +16,11 @@ jobs:
       with:
         fetch-depth: 0
         
-    # Install the .NET Core workload
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
+    # Setup .NET
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 3.1
+        dotnet-version: 8.0
         
     # Add MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         
@@ -24,7 +24,7 @@ jobs:
         
     # Add MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v2
       
     # Restore the application to populate the obj folder with RuntimeIdentifiers
     - name: Restore the application

--- a/FATX/FATX.csproj
+++ b/FATX/FATX.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
   </ItemGroup>
 
 </Project>

--- a/FATX/FileSystem/TimeStamp.cs
+++ b/FATX/FileSystem/TimeStamp.cs
@@ -26,6 +26,7 @@ namespace FATX.FileSystem
     {
         private uint _Time;
         private DateTime? _DateTime;
+        private readonly DateTime _minWinFileTime = new DateTime(1601, 01, 01);
 
         public TimeStamp(uint time)
         {
@@ -70,6 +71,11 @@ namespace FATX.FileSystem
         {
             if (this._DateTime.HasValue)
             {
+                if (this._DateTime < _minWinFileTime)
+                {
+                    return _minWinFileTime;
+                }
+
                 return this._DateTime.Value;
             }
             else

--- a/FATX/FileSystem/TimeStamp.cs
+++ b/FATX/FileSystem/TimeStamp.cs
@@ -103,7 +103,7 @@ namespace FATX.FileSystem
                     }
                     catch (Exception)
                     {
-                        _DateTime = DateTime.MinValue;
+                        _DateTime = _minWinFileTime;
                     }
 
                     return _DateTime.Value;

--- a/FATXTools/FATXTools.csproj
+++ b/FATXTools/FATXTools.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <OutputType>WinExe</OutputType>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -71,7 +71,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Text.Json">
-      <Version>4.7.2</Version>
+      <Version>8.0.3</Version>
     </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
According to the [documentation for minwinbase.h](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime), Win32 apps (and therefor Windows itself) can only handle date times as early as January 1st, 1601. However, .NET can handle date times as early as January 1st, 0001, resulting in an exception being thrown. To solve this, we now clamp the value returned by the `AsDateTime` function.

This merge also bumps the target framework from .NET Core 3.0 to .NET 8, and re-targets Windows 10, mostly for ease of installation, as .NET Core 3.0 is no longer supported.