### PR TITLE
Fixed an oversight with checking validity of a dirent's datetime in Metadata Analyzer

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
       
     # Upload the release build artifacts
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: FATXTools-Release
         path: FATXTools/bin/Release/

--- a/FATX/Analyzers/MetadataAnalyzer.cs
+++ b/FATX/Analyzers/MetadataAnalyzer.cs
@@ -256,7 +256,7 @@ namespace FATX.Analyzers
                 return false;
             }
 
-            if (dateTime.Day > MaxDays[dateTime.Month - 1])
+            if (dateTime.Day > MaxDays[dateTime.Month - 1] || dateTime.Day < 1)
             {
                 return false;
             }


### PR DESCRIPTION
As the title says. This fixes an issue I had with the Metadata Analyzer detecting false-positives.

Also updated build.yaml to use `actions/upload-artifact@v4`, which is necessary for GitHub Actions autobuilds.